### PR TITLE
fix: make useAtom options.select return correct val when swapped

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,3 +1,3 @@
 {
-  "printWidth": 100
+  "printWidth": 120
 }

--- a/docs/globals.html
+++ b/docs/globals.html
@@ -278,7 +278,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in react-atom-internal.ts:427</li>
+									<li>Defined in react-atom-internal.ts:434</li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -337,7 +337,7 @@ useAtom(atom) <span class="hljs-comment">// =&gt; { count: 100 }</span></code></
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in react-atom-internal.ts:385</li>
+									<li>Defined in react-atom-internal.ts:388</li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -352,19 +352,20 @@ useAtom(atom) <span class="hljs-comment">// =&gt; { count: 100 }</span></code></
 								they read its new state.</p>
 								<dl class="tsd-comment-tags">
 									<dt>example</dt>
-									<dd><pre><code class="language-jsx"><span class="hljs-keyword">import</span> {Atom, swap, useAtom} <span class="hljs-keyword">from</span> <span class="hljs-string">'@dbeining/react-atom'</span>
+									<dd><pre><code class="language-jsx">
+<span class="hljs-keyword">import</span> {Atom, swap, useAtom} <span class="hljs-keyword">from</span> <span class="hljs-string">'@dbeining/react-atom'</span>
 
 <span class="hljs-keyword">const</span> stateAtom = Atom.of({ <span class="hljs-attr">count</span>: <span class="hljs-number">0</span> })
 <span class="hljs-keyword">const</span> increment = <span class="hljs-function"><span class="hljs-params">()</span> =&gt;</span> swap(stateAtom, (state) =&gt; ({<span class="hljs-attr">count</span>: state.count + <span class="hljs-number">1</span>}))
 
 <span class="hljs-function"><span class="hljs-keyword">function</span> <span class="hljs-title">MyComponent</span>(<span class="hljs-params"></span>) </span>{
-  <span class="hljs-keyword">const</span> {count} = useAtom(stateAtom)
-  <span class="hljs-keyword">return</span> (
-   <span class="xml"><span class="hljs-tag">&lt;<span class="hljs-name">div</span>&gt;</span>
-     <span class="hljs-tag">&lt;<span class="hljs-name">p</span>&gt;</span>The count is {count}<span class="hljs-tag">&lt;/<span class="hljs-name">p</span>&gt;</span>
-     <span class="hljs-tag">&lt;<span class="hljs-name">button</span> <span class="hljs-attr">onClick</span>=<span class="hljs-string">{increment}</span>&gt;</span><span class="hljs-tag">&lt;/<span class="hljs-name">button</span>&gt;</span>
-   <span class="hljs-tag">&lt;/<span class="hljs-name">div</span>&gt;</span></span>
-  )
+ <span class="hljs-keyword">const</span> {count} = useAtom(stateAtom)
+ <span class="hljs-keyword">return</span> (
+  <span class="xml"><span class="hljs-tag">&lt;<span class="hljs-name">div</span>&gt;</span>
+    <span class="hljs-tag">&lt;<span class="hljs-name">p</span>&gt;</span>The count is {count}<span class="hljs-tag">&lt;/<span class="hljs-name">p</span>&gt;</span>
+    <span class="hljs-tag">&lt;<span class="hljs-name">button</span> <span class="hljs-attr">onClick</span>=<span class="hljs-string">{increment}</span>&gt;</span><span class="hljs-tag">&lt;/<span class="hljs-name">button</span>&gt;</span>
+  <span class="hljs-tag">&lt;/<span class="hljs-name">div</span>&gt;</span></span>
+ )
 }</code></pre>
 									</dd>
 								</dl>

--- a/test/swap.spec.tsx
+++ b/test/swap.spec.tsx
@@ -34,13 +34,6 @@ describe("swap function", () => {
     expect(getByTestId(container, "count").textContent).toBe("1");
   });
 
-  it("triggers a rerender on a Component that uses the swapped Atom", () => {
-    render(<ShowCount />);
-    swap(TEST_ATOM, s => ({ count: s.count + 1 }));
-    swap(TEST_ATOM, s => ({ count: s.count + 1 }));
-    expect(timesRendered).toBe(3);
-  });
-
   it("triggers a rerender on all Components that useAtom the swapped Atom", () => {
     render(<ShowCount />); // 1
     render(<ShowCount />); // 2
@@ -60,27 +53,75 @@ describe("swap function", () => {
     expect(timesRendered).toBe(5);
   });
 
-  it(`does not re-render components when they call useAtom with options.select and the current and next
-  state returned by options.select are shallowly equal`, () => {
-    const nums = [1, 2, 3, 4, 5];
-    const TEST_ATOM = Atom.of({ nums });
-    let timesRendered = 0;
+  describe("re-rendering components that call useAtom with options.select", () => {
+    it("makes components re-render with the next selected state", () => {
+      const a = { a: "a" };
+      const b = { a: "a" };
+      const c = { a: "a" };
+      const d = { a: "a" };
+      const vals = [a, b, c, d];
+      const TEST_ATOM = Atom.of(vals);
 
-    function ShowCount() {
-      const { nums: n } = useAtom(TEST_ATOM, { select: s => s });
-      timesRendered += 1;
-      return (
-        <div>
-          <p>this doesn't matter</p>
-        </div>
-      );
-    }
+      function ShowCount<T>({ selector }: { selector: (s: Array<typeof b>) => T }) {
+        const val = useAtom(TEST_ATOM, { select: selector });
+        return (
+          <div>
+            <p data-testid={"target"}>{val}</p>
+          </div>
+        );
+      }
 
-    render(<ShowCount />); // render 1
-    swap(TEST_ATOM, s => s); // shouldn't trigger a render
-    swap(TEST_ATOM, s => s); // shouldn't trigger a render
-    swap(TEST_ATOM, s => s); // shouldn't trigger a render
-    swap(TEST_ATOM, s => ({ ...s, nums: [1, 2, 3, 4, 5] })); // render 2
-    expect(timesRendered).toBe(2);
+      const { container: c1 } = render(<ShowCount selector={s => s[2].a} />);
+      const { container: c2 } = render(<ShowCount selector={s => s.length} />);
+
+      expect(getByTestId(c1, "target").textContent).toBe("a");
+      expect(getByTestId(c2, "target").textContent).toBe("4");
+
+      swap(TEST_ATOM, s => s.map(v => ({ a: v.a.toUpperCase() })));
+      expect(getByTestId(c1, "target").textContent).toBe("A");
+      expect(getByTestId(c2, "target").textContent).toBe("4");
+
+      swap(TEST_ATOM, s => s.map(v => ({ a: "hello" })).slice(0, 3));
+      expect(getByTestId(c1, "target").textContent).toBe("hello");
+      expect(getByTestId(c2, "target").textContent).toBe("3");
+    });
+
+    it("prevents components from re-rendering when the value selected has not changed", () => {
+      const a = { a: "a" };
+      const b = { a: "a" };
+      const c = { a: "a" };
+      const d = { a: "a" };
+      const vals = [a, b, c, d];
+      const TEST_ATOM = Atom.of(vals);
+      let timesRendered = 0;
+
+      function ShowCount() {
+        const vals = useAtom(TEST_ATOM, { select: s => ({ length: s.length, val: s[2] }) });
+        timesRendered += 1;
+        return (
+          <div>
+            <p>this doesn't matter</p>
+          </div>
+        );
+      }
+
+      render(<ShowCount />); // render 1
+      expect(timesRendered).toBe(1);
+
+      swap(TEST_ATOM, v => v); // didn't change; shouldn't rerender
+      expect(timesRendered).toBe(1);
+
+      swap(TEST_ATOM, () => [a, b, c, d]); // changed but shallowly equal; shouldn't rerender
+      expect(timesRendered).toBe(1);
+
+      swap(TEST_ATOM, () => [a, c, b, d]); // changed; not shallow eq; rerender!
+      expect(timesRendered).toBe(2);
+
+      swap(TEST_ATOM, () => [a, c, b, d]); // no change; shouldn't rerender
+      expect(timesRendered).toBe(2);
+
+      swap(TEST_ATOM, () => [a, c, b]); // change; rerender!
+      expect(timesRendered).toBe(3);
+    });
   });
 });

--- a/test/useAtom.spec.tsx
+++ b/test/useAtom.spec.tsx
@@ -117,13 +117,11 @@ describe("useAtom function", () => {
   describe("options.select", () => {
     it("is applied to the Atom state to derive the value to use", () => {
       const TEST_ATOM = Atom.of({ nums: [1, 2, 3, 4, 5] });
-      let timesRendered = 0;
 
       function Sum() {
         const sum = useAtom(TEST_ATOM, {
           select: s => s.nums.reduce((a, b) => a + b)
         });
-        timesRendered += 1;
 
         return (
           <div>
@@ -146,31 +144,6 @@ describe("useAtom function", () => {
 
       function Sum({ getter }: { getter: (s: typeof state) => number }) {
         const sum = useAtom(TEST_ATOM, { select: getter });
-        timesRendered += 1;
-
-        return (
-          <div>
-            <p data-testid="target">{sum}</p>
-          </div>
-        );
-      }
-
-      const { container: c1 } = render(<Sum getter={getter1} />);
-      expect(getByTestId(c1, "target").textContent).toBe("15");
-
-      const { container: c2 } = render(<Sum getter={getter2} />);
-      expect(getByTestId(c2, "target").textContent).toBe("-13");
-    });
-
-    it("defaults to the identity function when falsey", () => {
-      const TEST_ATOM = Atom.of({ nums: [1, 2, 3, 4, 5] });
-      const state = getAtomVal(TEST_ATOM);
-      const getter1 = (s: typeof state) => s.nums.reduce((a, b) => a + b);
-      const getter2 = (s: typeof state) => s.nums.reduce((a, b) => a - b);
-
-      function Sum({ getter }: { getter: (s: typeof state) => number }) {
-        const sum = useAtom(TEST_ATOM, { select: getter });
-        timesRendered += 1;
 
         return (
           <div>

--- a/tsconfig.jest.json
+++ b/tsconfig.jest.json
@@ -1,14 +1,14 @@
 {
   "compilerOptions": {
     "allowJs": true,
-    "diagnostics": false,
+    "diagnostics": true,
     "esModuleInterop": true,
     "lib": ["dom", "es2018"],
     "jsx": "react",
     "moduleResolution": "node",
     "noImplicitAny": true,
     "outDir": "./dist/",
-    "rootDir": "src",
+    "rootDir": "test",
     "sourceMap": true,
     "strict": true,
     "typeRoots": ["node_modules/@types", "src"]


### PR DESCRIPTION
discovered that options.select in useAtom was not being used correctly in `swap` such that
components using `select` ended up with just atom state and not selected state

fix #27