### PR TITLE
Determine if a component is mounted before running the hook

### DIFF
--- a/src/react-atom-internal.ts
+++ b/src/react-atom-internal.ts
@@ -76,14 +76,16 @@ export function initialize(hooks: HookDependencies): PublicExports {
     useLayoutEffect(
       () => {
         const idKey = hook["@@react-atom/hook_id"] ? hook["@@react-atom/hook_id"] : `hook#${++hookIdTicker}`;
+        let isMounted = true;
         hook["@@react-atom/hook_id"] = idKey;
         addChangeHandler(atom, hook["@@react-atom/hook_id"], ({ previous, current }) => {
-          if (!isShallowEqual(selector(previous), selector(current))) {
+          if (isMounted && !isShallowEqual(selector(previous), selector(current))) {
             hook({} as SetStateAction<S | R>);
           }
         });
 
         return function unhook() {
+          isMounted = false;
           removeChangeHandler(atom, hook["@@react-atom/hook_id"] as string);
         };
       },


### PR DESCRIPTION
Part of two pull requests. Please see @libre/Atom for corresponding pull request.

Change handlers may persist due to copying the handler list before executing in @libre/Atom.
So we need to make sure the component is still mounted before executing the hook. 

#44 & libre-org/atom/pull/11